### PR TITLE
Also hide comments starting with 'Continued from previous comment.'

### DIFF
--- a/server/events/vcs/azuredevops_client.go
+++ b/server/events/vcs/azuredevops_client.go
@@ -90,17 +90,12 @@ func (g *AzureDevopsClient) GetModifiedFiles(repo models.Repo, pull models.PullR
 // If comment length is greater than the max comment length we split into
 // multiple comments.
 func (g *AzureDevopsClient) CreateComment(repo models.Repo, pullNum int, comment string, command string) error {
-	sepEnd := "\n```\n</details>" +
-		"\n<br>\n\n**Warning**: Output length greater than max comment size. Continued in next comment."
-	sepStart := "Continued from previous comment.\n<details><summary>Show Output</summary>\n\n" +
-		"```diff\n"
-
 	// maxCommentLength is the maximum number of chars allowed in a single comment
 	// This length was copied from the Github client - haven't found documentation
 	// or tested limit in Azure DevOps.
 	const maxCommentLength = 65536
 
-	comments := common.SplitComment(comment, maxCommentLength, sepEnd, sepStart)
+	comments := common.SplitComment(comment, maxCommentLength)
 	owner, project, repoName := SplitAzureDevopsRepoFullName(repo.FullName)
 
 	for _, c := range comments {

--- a/server/events/vcs/bitbucketserver/client.go
+++ b/server/events/vcs/bitbucketserver/client.go
@@ -130,9 +130,7 @@ func (b *Client) GetProjectKey(repoName string, cloneURL string) (string, error)
 // CreateComment creates a comment on the merge request. It will write multiple
 // comments if a single comment is too long.
 func (b *Client) CreateComment(repo models.Repo, pullNum int, comment string, command string) error {
-	sepEnd := "\n```\n**Warning**: Output length greater than max comment size. Continued in next comment."
-	sepStart := "Continued from previous comment.\n```diff\n"
-	comments := common.SplitComment(comment, maxCommentLength, sepEnd, sepStart)
+	comments := common.SplitComment(comment, maxCommentLength)
 	for _, c := range comments {
 		if err := b.postComment(repo, pullNum, c); err != nil {
 			return err

--- a/server/events/vcs/common/common.go
+++ b/server/events/vcs/common/common.go
@@ -10,25 +10,34 @@ import (
 // merging pull requests.
 const AutomergeCommitMsg = "[Atlantis] Automatically merging after successful apply"
 
+// SepStartComment is the first line of comment when a plan needs to be extended to
+// multiple comments.
+const SepStartComment string = "Continued from previous comment.\n<details><summary>Show Output</summary>\n\n```diff\n"
+
+// SepStartComment is the last line of the first comment when a plan needs to be
+// extended to multiple comments.
+const SepEndComment string = "\n```\n</details>" +
+	"\n<br>\n\n**Warning**: Output length greater than max comment size. Continued in next comment."
+
 // SplitComment splits comment into a slice of comments that are under maxSize.
-// It appends sepEnd to all comments that have a following comment.
-// It prepends sepStart to all comments that have a preceding comment.
-func SplitComment(comment string, maxSize int, sepEnd string, sepStart string) []string {
+// It appends SepEndComment to all comments that have a following comment.
+// It prepends SepStartComment to all comments that have a preceding comment.
+func SplitComment(comment string, maxSize int) []string {
 	if len(comment) <= maxSize {
 		return []string{comment}
 	}
 
-	maxWithSep := maxSize - len(sepEnd) - len(sepStart)
+	maxWithSep := maxSize - len(SepEndComment) - len(SepStartComment)
 	var comments []string
 	numComments := int(math.Ceil(float64(len(comment)) / float64(maxWithSep)))
 	for i := 0; i < numComments; i++ {
 		upTo := min(len(comment), (i+1)*maxWithSep)
 		portion := comment[i*maxWithSep : upTo]
 		if i < numComments-1 {
-			portion += sepEnd
+			portion += SepEndComment
 		}
 		if i > 0 {
-			portion = sepStart + portion
+			portion = SepStartComment + portion
 		}
 		comments = append(comments, portion)
 	}

--- a/server/events/vcs/common/common_test.go
+++ b/server/events/vcs/common/common_test.go
@@ -25,7 +25,7 @@ import (
 // If under the maximum number of chars, we shouldn't split the comments.
 func TestSplitComment_UnderMax(t *testing.T) {
 	comment := "comment under max size"
-	split := common.SplitComment(comment, len(comment)+1, "sepEnd", "sepStart")
+	split := common.SplitComment(comment, len(comment)+1)
 	Equals(t, []string{comment}, split)
 }
 
@@ -33,31 +33,27 @@ func TestSplitComment_UnderMax(t *testing.T) {
 // separators properly.
 func TestSplitComment_TwoComments(t *testing.T) {
 	comment := strings.Repeat("a", 1000)
-	sepEnd := "-sepEnd"
-	sepStart := "-sepStart"
-	split := common.SplitComment(comment, len(comment)-1, sepEnd, sepStart)
+	split := common.SplitComment(comment, len(comment)-1)
 
-	expCommentLen := len(comment) - len(sepEnd) - len(sepStart) - 1
+	expCommentLen := len(comment) - len(common.SepEndComment) - len(common.SepStartComment) - 1
 	expFirstComment := comment[:expCommentLen]
 	expSecondComment := comment[expCommentLen:]
 	Equals(t, 2, len(split))
-	Equals(t, expFirstComment+sepEnd, split[0])
-	Equals(t, sepStart+expSecondComment, split[1])
+	Equals(t, expFirstComment+common.SepEndComment, split[0])
+	Equals(t, common.SepStartComment+expSecondComment, split[1])
 }
 
 // If the comment needs to be split into 4 we should do the split and add the
 // separators properly.
 func TestSplitComment_FourComments(t *testing.T) {
 	comment := strings.Repeat("a", 1000)
-	sepEnd := "-sepEnd"
-	sepStart := "-sepStart"
-	max := (len(comment) / 4) + len(sepEnd) + len(sepStart)
-	split := common.SplitComment(comment, max, sepEnd, sepStart)
+	max := (len(comment) / 4) + len(common.SepEndComment) + len(common.SepStartComment)
+	split := common.SplitComment(comment, max)
 
 	expMax := len(comment) / 4
 	Equals(t, []string{
-		comment[:expMax] + sepEnd,
-		sepStart + comment[expMax:expMax*2] + sepEnd,
-		sepStart + comment[expMax*2:expMax*3] + sepEnd,
-		sepStart + comment[expMax*3:]}, split)
+		comment[:expMax] + common.SepEndComment,
+		common.SepStartComment + comment[expMax:expMax*2] + common.SepEndComment,
+		common.SepStartComment + comment[expMax*2:expMax*3] + common.SepEndComment,
+		common.SepStartComment + comment[expMax*3:]}, split)
 }

--- a/server/events/vcs/github_client.go
+++ b/server/events/vcs/github_client.go
@@ -198,7 +198,7 @@ func (g *GithubClient) HidePrevPlanComments(repo models.Repo, pullNum int) error
 			continue
 		}
 		firstLine := strings.ToLower(body[0])
-		if !strings.Contains(firstLine, models.PlanCommand.String()) && !strings.Contains(firstLine, "Continued from previous comment.") {
+		if !(strings.Contains(firstLine, models.PlanCommand.String()) || strings.Contains(firstLine, strings.ToLower("Continued from previous comment."))) {
 			continue
 		}
 		var m struct {

--- a/server/events/vcs/github_client.go
+++ b/server/events/vcs/github_client.go
@@ -138,20 +138,7 @@ func (g *GithubClient) GetModifiedFiles(repo models.Repo, pull models.PullReques
 // If comment length is greater than the max comment length we split into
 // multiple comments.
 func (g *GithubClient) CreateComment(repo models.Repo, pullNum int, comment string, command string) error {
-	var sepStart string
-
-	sepEnd := "\n```\n</details>" +
-		"\n<br>\n\n**Warning**: Output length greater than max comment size. Continued in next comment."
-
-	if command != "" {
-		sepStart = fmt.Sprintf("Continued %s output from previous comment.\n<details><summary>Show Output</summary>\n\n", command) +
-			"```diff\n"
-	} else {
-		sepStart = "Continued from previous comment.\n<details><summary>Show Output</summary>\n\n" +
-			"```diff\n"
-	}
-
-	comments := common.SplitComment(comment, maxCommentLength, sepEnd, sepStart)
+	comments := common.SplitComment(comment, maxCommentLength)
 	for _, c := range comments {
 		g.logger.Debug("POST /repos/%v/%v/issues/%d/comments", repo.Owner, repo.Name, pullNum)
 		_, _, err := g.client.Issues.CreateComment(g.ctx, repo.Owner, repo.Name, pullNum, &github.IssueComment{Body: &c})
@@ -190,15 +177,19 @@ func (g *GithubClient) HidePrevPlanComments(repo models.Repo, pullNum int) error
 			continue
 		}
 		// Crude filtering: The comment templates typically include the command name
-		// somewhere in the first line. It's a bit of an assumption, but seems like
-		// a reasonable one, given we've already filtered the comments by the
-		// configured Atlantis user.
-		body := strings.Split(comment.GetBody(), "\n")
-		if len(body) == 0 {
+		// somewhere in the first line or starts with the split separator text. It's
+		// a bit of an assumption, but seems like a reasonable one, given we've
+		// already filtered the comments by the configured Atlantis user.
+		body := comment.GetBody()
+		splitBody := strings.Split(comment.GetBody(), "\n")
+		if len(splitBody) == 0 {
 			continue
 		}
-		firstLine := strings.ToLower(body[0])
-		if !(strings.Contains(firstLine, models.PlanCommand.String()) || strings.Contains(firstLine, strings.ToLower("Continued from previous comment."))) {
+		firstLine := strings.ToLower(splitBody[0])
+		commentFirstLineContainsCommand := strings.Contains(firstLine, models.PlanCommand.String())
+		commentStartsWithSepStartComment := strings.HasPrefix(body, common.SepStartComment)
+
+		if !(commentFirstLineContainsCommand || commentStartsWithSepStartComment) {
 			continue
 		}
 		var m struct {

--- a/server/events/vcs/github_client.go
+++ b/server/events/vcs/github_client.go
@@ -198,7 +198,7 @@ func (g *GithubClient) HidePrevPlanComments(repo models.Repo, pullNum int) error
 			continue
 		}
 		firstLine := strings.ToLower(body[0])
-		if !strings.Contains(firstLine, models.PlanCommand.String()) {
+		if !strings.Contains(firstLine, models.PlanCommand.String()) && !strings.Contains(firstLine, "Continued from previous comment.") {
 			continue
 		}
 		var m struct {

--- a/server/events/vcs/github_client_test.go
+++ b/server/events/vcs/github_client_test.go
@@ -235,8 +235,10 @@ func TestGithubClient_PaginatesComments(t *testing.T) {
 }
 
 func TestGithubClient_HideOldComments(t *testing.T) {
-	// Only comment 6 should be minimized, because it's by the same Atlantis bot user
-	// and it has "plan" in the first line of the comment body.
+  // Only comments 6, 8 and 9 should be minimized, because:
+  //   * it's by the same Atlantis bot user
+	//   * it has "plan" or "Continued from previous comment." in the first line of the
+  //     comment body.
 	issueResp := `[
 	{"node_id": "1", "body": "asd\nplan\nasd", "user": {"login": "someone-else"}},
 	{"node_id": "2", "body": "asd plan\nasd", "user": {"login": "someone-else"}},
@@ -246,7 +248,7 @@ func TestGithubClient_HideOldComments(t *testing.T) {
 	{"node_id": "6", "body": "asd plan\nasd", "user": {"login": "user"}},
 	{"node_id": "7", "body": "asdasdasd", "user": {"login": "user"}},
 	{"node_id": "8", "body": "asd plan\nasd", "user": {"login": "user"}},
-	{"node_id": "9", "body": "Continued Plan from previous comment\nasd", "user": {"login": "user"}}
+	{"node_id": "9", "body": "Continued from previous comment.\nasd", "user": {"login": "user"}}
 ]`
 	minimizeResp := "{}"
 	type graphQLCall struct {
@@ -317,6 +319,7 @@ func TestGithubClient_HideOldComments(t *testing.T) {
 	Ok(t, err)
 	Equals(t, 3, len(gotMinimizeCalls))
 	Equals(t, "6", gotMinimizeCalls[0].Variables.Input.SubjectID)
+	Equals(t, "8", gotMinimizeCalls[1].Variables.Input.SubjectID)
 	Equals(t, "9", gotMinimizeCalls[2].Variables.Input.SubjectID)
 	Equals(t, githubv4.ReportedContentClassifiersOutdated, gotMinimizeCalls[0].Variables.Input.Classifier)
 }

--- a/server/events/vcs/github_client_test.go
+++ b/server/events/vcs/github_client_test.go
@@ -235,10 +235,10 @@ func TestGithubClient_PaginatesComments(t *testing.T) {
 }
 
 func TestGithubClient_HideOldComments(t *testing.T) {
-  // Only comments 6, 8 and 9 should be minimized, because:
-  //   * it's by the same Atlantis bot user
+	// Only comments 6, 8 and 9 should be minimized, because:
+	//   * it's by the same Atlantis bot user
 	//   * it has "plan" or "Continued from previous comment." in the first line of the
-  //     comment body.
+	//     comment body.
 	issueResp := `[
 	{"node_id": "1", "body": "asd\nplan\nasd", "user": {"login": "someone-else"}},
 	{"node_id": "2", "body": "asd plan\nasd", "user": {"login": "someone-else"}},


### PR DESCRIPTION
This is needed when plans are very long and need to be split in multiple comments.